### PR TITLE
add recursive tree traversal via *Recursive() method alternatives

### DIFF
--- a/lib/xmldoc.js
+++ b/lib/xmldoc.js
@@ -106,6 +106,42 @@ XmlElement.prototype.childWithAttribute = function(name,value) {
   }
 }
 
+XmlElement.prototype.childWithAttributeRecursive = function(name, value) {
+  for (var i = 0, l = this.children.length; i < l; i++) {
+    var child = this.children[i];
+    if ( (value && child.attr[name] === value) || (!value && child.attr[name]) )
+      return child;
+    var child_recursive = child.childWithAttributeRecursive(name, value);
+    if (child_recursive) return child_recursive;
+  }
+}
+
+XmlElement.prototype.childrenWithAttribute = function(name, value) {
+  var matches = [];
+
+  for (var i = 0, l = this.children.length; i < l; i++) {
+    var child = this.children[i];
+    if ( (value && child.attr[name] === value) || (!value && child.attr[name]) )
+      matches.push(child);
+    matches = matches.concat(child.childrenWithAttribute(name, value));
+  }
+
+  return matches;
+}
+
+XmlElement.prototype.childrenWithAttributeRecursive = function(name, value) {
+  var matches = [];
+
+  for (var i = 0, l = this.children.length; i < l; i++) {
+    var child = this.children[i];
+    if ( (value && child.attr[name] === value) || (!value && child.attr[name]) )
+      matches.push(child);
+    matches = matches.concat(child.childWithAttributeRecursive(name, value));
+  }
+
+  return matches;
+}
+
 XmlElement.prototype.descendantWithPath = function(path) {
   var descendant = this;
   var components = path.split('.');

--- a/lib/xmldoc.js
+++ b/lib/xmldoc.js
@@ -67,12 +67,33 @@ XmlElement.prototype.childNamed = function(name) {
   }
 }
 
+XmlElement.prototype.childNamedRecursive = function(name) {
+  for (var i=0, l=this.children.length; i<l; i++) {
+    var child = this.children[i];
+    if (child.name === name) return child;
+    var child_recursive = child.childNamedRecursive(name);
+    if (child_recursive) return child_recursive;
+  }
+}
+
 XmlElement.prototype.childrenNamed = function(name) {
   var matches = [];
 
   for (var i=0, l=this.children.length; i<l; i++)
     if (this.children[i].name === name)
       matches.push(this.children[i]);
+
+  return matches;
+}
+
+XmlElement.prototype.childrenNamedRecursive = function(name) {
+  var matches = [];
+
+  for (var i = 0, l = this.children.length; i < l; i++) {
+    if (this.children[i].name === name)
+      matches.push(this.children[i]);
+    matches = matches.concat(this.children[i].childrenNamedRecursive(name));
+  }
 
   return matches;
 }


### PR DESCRIPTION
This makes it possible to do deep-level traversal such as `getElementsByTagName()` would.

```html
<a>
  <b>
    <c id="1" />
  </b>
  <c id="2">
    <c id="3" />
  </c>
</a>
```

JS:

```javascript
a.childNamedRecursive('c') // -> c#1
a.childrenNamedRecursive('c') // -> [ c#1, c#2, c#3 ]
a.childWithAttributeRecursive('id', '3') // -> c#3
a.childrenWithAttributeRecursive('id') // -> [ c#1, c#2, c#3 ]
```