### PR TITLE
add whole document serialization via toString(whole=true, compressed=true)

### DIFF
--- a/lib/xmldoc.js
+++ b/lib/xmldoc.js
@@ -107,34 +107,36 @@ XmlElement.prototype.valueWithPath = function(path) {
 
 // String formatting (for debugging)
 
-XmlElement.prototype.toString = function() {
-  return this.toStringWithIndent("");
+var indent = function(level) {
+  return new Array(level + 1).join("  ");
+};
+
+XmlElement.prototype.toString = function(whole, compressed) {
+  return this.toStringWithIndent(0, !whole, !compressed);
 }
 
-XmlElement.prototype.toStringWithIndent = function(indent) {
+XmlElement.prototype.toStringWithIndent = function(indentLevel, trim, indented) {
   var s = "";
-  s += indent + "<" + this.name;
+  s += (indented ? indent(indentLevel) : '') + "<" + this.name;
   
   for (var name in this.attr)
     s += " " + name + '="' + this.attr[name] + '"';
 
   var trimVal = this.val.trim();
 
-  if (trimVal.length > 25)
+  if (trim && trimVal.length > 25)
     trimVal = trimVal.substring(0,25).trim() + "…";
   
   if (this.children.length) {
     s += ">\n";
     
-    var childIndent = indent + "  ";
-    
     if (trimVal.length)
-      s += childIndent + trimVal + "\n";
+      s += (indented ? indent(indentLevel + 1) : '') + trimVal + "\n";
 
     for (var i=0, l=this.children.length; i<l; i++)
-      s += this.children[i].toStringWithIndent(childIndent) + "\n";
+      s += this.children[i].toStringWithIndent(indentLevel + 1, trim, indented) + "\n";
     
-    s += indent + "</" + this.name + ">";
+    s += (indented ? indent(indentLevel) : '') + "</" + this.name + ">";
   }
   else if (trimVal.length) {
     s += ">" + trimVal + "</" + this.name +">";


### PR DESCRIPTION
This makes it possible to serialize the **whole** document/subtree as a usable valid XML string.

``` javascript
doc.toString() // -> as before, trimmed and indented
doc.toString(true) // -> untrimmed and indented
doc.toString(true, true) // -> untrimmed and unindented
doc.toString(false, true) // -> trimmed and unindented
```
