### PR TITLE
Add escaping '<' and '>' in toString()

### DIFF
--- a/lib/xmldoc.js
+++ b/lib/xmldoc.js
@@ -126,7 +126,7 @@ XmlElement.prototype.toStringWithIndent = function(indent, options) {
     if (Object.prototype.hasOwnProperty.call(this.attr, name))
         s += " " + name + '="' + this.attr[name] + '"';
 
-  var finalVal = this.val.trim();
+  var finalVal = this.val.trim().replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
   if (options && options.trimmed && finalVal.length > 25)
     finalVal = finalVal.substring(0,25).trim() + "…";


### PR DESCRIPTION
Add escaping of '<' and '>' in toString, because otherwise it doesn't return valid xml (which I actually need). 
