### PR TITLE
encode attribute values to keep xml valid

### DIFF
--- a/lib/xmldoc.js
+++ b/lib/xmldoc.js
@@ -137,7 +137,7 @@ XmlElement.prototype.toStringWithIndent = function(indent, options) {
   
   for (var name in this.attr)
     if (Object.prototype.hasOwnProperty.call(this.attr, name))
-        s += " " + name + '="' + this.attr[name] + '"';
+        s += " " + name + '="' + encodeURIComponent(this.attr[name]) + '"';
 
   var finalVal = this.val.trim().replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/&/g, '&amp;');
 


### PR DESCRIPTION
feedburner (a very popular RSS provider) has an attribute that inserts unescaped ampersands which causes invalid xml when returned, this change fixes it without affecting non-attribute values

`&fileName` in:

<ns0:feedFlare xmlns:ns0="http://rssnamespace.org/feedburner/ext/1.0" href="http://www.pageflakes.com/subscribe.aspx?url=http%3A%2F%2Ffeeds.reuters.com%2Freuters%2FMostRead" src="http://www.pageflakes.com/ImageFile.ashx?instanceId=Static_4&fileName=ATP_blu_91x17.gif">Subscribe with Pageflakes</ns0:feedFlare>