### PR TITLE
Fix escaping of xml values and attributes

### DIFF
--- a/lib/xmldoc.js
+++ b/lib/xmldoc.js
@@ -69,6 +69,10 @@ XmlElement.prototype._error = function(err) {
   throw err;
 };
 
+XmlElement.prototype._escape = function(value){
+  var result = value.replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/&/g, '&amp;').replace(/'/g, '&apos;').replace(/"/g, '&quot;');
+  return result;
+}
 // Useful functions
 
 XmlElement.prototype.eachChild = function(iterator, context) {
@@ -137,9 +141,9 @@ XmlElement.prototype.toStringWithIndent = function(indent, options) {
   
   for (var name in this.attr)
     if (Object.prototype.hasOwnProperty.call(this.attr, name))
-        s += " " + name + '="' + encodeURIComponent(this.attr[name]) + '"';
+        s += " " + name + '="' + this._escape(this.attr[name]) + '"';
 
-  var finalVal = this.val.trim().replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/&/g, '&amp;');
+  var finalVal = this._escape(this.val);
 
   if (options && options.trimmed && finalVal.length > 25)
     finalVal = finalVal.substring(0,25).trim() + "…";


### PR DESCRIPTION
When using toString the encoding is incorrect. It uses UriEncode for attributes which means e.g. a " becomes %22 not &quot&quot;
Also some escape characters were missing in encoding values, e.g. &apos; and &quot;