### PR TITLE
Fixing #29 - Incorrect escaping of &lt; &gt;

### DIFF
--- a/lib/xmldoc.js
+++ b/lib/xmldoc.js
@@ -247,7 +247,7 @@ function extend(destination, source) {
 
 // escapes XML entities like "<", "&", etc.
 function escapeXML(value){
-  return value.replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/&/g, '&amp;').replace(/'/g, '&apos;').replace(/"/g, '&quot;');
+  return value.replace(/&/g, '&amp;').replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/'/g, '&apos;').replace(/"/g, '&quot;');
 }
 
 // Are we being used in a Node-like environment?

--- a/test/issues.js
+++ b/test/issues.js
@@ -7,3 +7,12 @@ t.test('parsing comments outside XML scope [#27]', function (t) {
   var parsed = new XmlDocument(xmlString);
   t.end();
 })
+
+t.test('validating escaping of &lt; &gt; [#29]', function (t) {
+  
+  var xmlString = '<root><command>&lt; &gt;</command></root>';
+  var parsed = new XmlDocument(xmlString);
+  var result = parsed.toString({compressed:true})
+  t.equal(result, xmlString);
+  t.end();
+})


### PR DESCRIPTION
Pull request for issue #29 - By changing the priority of the replace statements the incorrect escaping can be prevented.