### PR TITLE
Correctly handle (discard) tags that come after the root XML document node

### DIFF
--- a/lib/xmldoc.js
+++ b/lib/xmldoc.js
@@ -212,6 +212,10 @@ XmlDocument.prototype._opentag = function(tag) {
     XmlElement.prototype._opentag.apply(this,arguments);
 };
 
+XmlDocument.prototype._closetag = function() {
+  // we DON'T want to unshift the delegates or else we'll "fall off" the stack.
+}
+
 // file-scoped global stack of delegates
 var delegates = null;
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -45,6 +45,7 @@ t.test('parse xml', function (t) {
   var parsed = new XmlDocument(xmlString);
   t.ok(parsed);
   t.throws(function() { new XmlDocument(); });
+  t.throws(function() { new XmlDocument("  "); });
   t.end();
 })
 

--- a/test/issues.js
+++ b/test/issues.js
@@ -1,0 +1,9 @@
+var XmlDocument = require('../').XmlDocument
+var t = require('tap')
+
+t.test('parsing comments outside XML scope [#27]', function (t) {
+  
+  var xmlString = '<hello>world</hello>\n<!--Thank you for your business!-->';
+  var parsed = new XmlDocument(xmlString);
+  t.end();
+})


### PR DESCRIPTION
Fixes #27