### PR TITLE
Support XML comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 node_modules/
 
 # Code Coverage
+.nyc_output/
 coverage/

--- a/lib/xmldoc.js
+++ b/lib/xmldoc.js
@@ -27,6 +27,7 @@ function XmlElement(tag) {
   this.attr = tag.attributes;
   this.val = "";
   this.isValCdata = false;
+  this.isValComment = false;
   this.children = [];
   this.firstChild = null;
   this.lastChild = null;
@@ -66,6 +67,11 @@ XmlElement.prototype._cdata = function(cdata) {
   this.val += cdata;
   this.isValCdata=true;
 };
+
+XmlElement.prototype._comment = function(comment) {
+  this.val += comment;
+  this.isValComment=true;
+}
 
 XmlElement.prototype._error = function(err) {
   throw err;
@@ -212,10 +218,6 @@ XmlDocument.prototype._opentag = function(tag) {
     XmlElement.prototype._opentag.apply(this,arguments);
 };
 
-XmlDocument.prototype._closetag = function() {
-  // we DON'T want to unshift the delegates or else we'll "fall off" the stack.
-}
-
 // file-scoped global stack of delegates
 var delegates = null;
 
@@ -228,15 +230,17 @@ function addParserEvents(parser) {
   parser.onclosetag = parser_closetag;
   parser.ontext = parser_text;
   parser.oncdata = parser_cdata;
+  parser.oncomment = parser_comment;
   parser.onerror = parser_error;
 }
 
 // create these closures and cache them by keeping them file-scoped
-function parser_opentag() { delegates[0]._opentag.apply(delegates[0],arguments) }
-function parser_closetag() { delegates[0]._closetag.apply(delegates[0],arguments) }
-function parser_text() { delegates[0]._text.apply(delegates[0],arguments) }
-function parser_cdata() { delegates[0]._cdata.apply(delegates[0],arguments) }
-function parser_error() { delegates[0]._error.apply(delegates[0],arguments) }
+function parser_opentag() { delegates[0] && delegates[0]._opentag.apply(delegates[0],arguments) }
+function parser_closetag() { delegates[0] && delegates[0]._closetag.apply(delegates[0],arguments) }
+function parser_text() { delegates[0] && delegates[0]._text.apply(delegates[0],arguments) }
+function parser_cdata() { delegates[0] && delegates[0]._cdata.apply(delegates[0],arguments) }
+function parser_comment() { delegates[0] && delegates[0]._comment.apply(delegates[0],arguments) }
+function parser_error() { delegates[0] && delegates[0]._error.apply(delegates[0],arguments) }
 
 // a relatively standard extend method
 function extend(destination, source) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -54,6 +54,16 @@ t.test('cdata handling', function (t) {
   var xmlString = '<hello><![CDATA[<world>]]></hello>';
   var parsed = new XmlDocument(xmlString);
   t.equal(parsed.val, "<world>");
+  t.equal(parsed.isValCdata, true);
+  t.end();
+})
+
+t.test('comment handling', function (t) {
+  
+  var xmlString = '<hello><!-- World --></hello>';
+  var parsed = new XmlDocument(xmlString);
+  t.equal(parsed.val, " World ");
+  t.equal(parsed.isValComment, true);
   t.end();
 })
 

--- a/test/issues.js
+++ b/test/issues.js
@@ -5,6 +5,10 @@ t.test('parsing comments outside XML scope [#27]', function (t) {
   
   var xmlString = '<hello>world</hello>\n<!--Thank you for your business!-->';
   var parsed = new XmlDocument(xmlString);
+  
+  // verify that the trailing comment is ignored (no sensible place to put it)
+  t.equal(parsed.toString(), '<hello>world</hello>');
+  
   t.end();
 })
 


### PR DESCRIPTION
Fixes #22

Also discards "extra" XML information outside the first root node, like
trailing comments or extra nodes, since we have no sensible place to
store them in our data structure.