### PR TITLE
Added mixedChildren array to save multiple values

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -22,7 +22,7 @@ var fs = require('fs'),
     path = require('path');
 
 fs.readFile(path.join(__dirname, "test.xml"), 'utf8', function (err,data) {
-  
+
   if (err) {
     return console.log(err);
   }
@@ -57,4 +57,18 @@ fs.readFile(path.join(__dirname, "test.xml"), 'utf8', function (err,data) {
   console.log("Title of book with given ISBN: '%s'", twilight.valueWithPath("title"));
 
   return null;
+});
+
+fs.readFile(path.join(__dirname, "mixed.xml"), 'utf8', function (err,data) {
+
+  if (err) {
+    return console.log(err);
+  }
+
+  // Parse the XML
+  var results = new XmlDocument(data);
+  results.mixedChildren.forEach((c,i) => {
+    console.log('Child number: ' + i)
+    console.log(c)
+  })
 });

--- a/examples/mixed.xml
+++ b/examples/mixed.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sometag><FirstChild>first Child's text</FirstChild>First value<SecondChild>Second Child's text</SecondChild>Second Value<ThirdChild>Third child's text</ThirdChild>Third value</sometag>

--- a/lib/xmldoc.js
+++ b/lib/xmldoc.js
@@ -29,6 +29,7 @@ function XmlElement(tag) {
   this.isValCdata = false;
   this.isValComment = false;
   this.children = [];
+  this.mixedChildren = [];
   this.firstChild = null;
   this.lastChild = null;
 
@@ -44,10 +45,10 @@ function XmlElement(tag) {
 XmlElement.prototype._opentag = function(tag) {
 
   var child = new XmlElement(tag);
-  
+
   // add to our children array
   this.children.push(child);
-
+  this.mixedChildren.push(child);
   // update first/last pointers
   if (!this.firstChild) this.firstChild = child;
   this.lastChild = child;
@@ -61,16 +62,19 @@ XmlElement.prototype._closetag = function() {
 
 XmlElement.prototype._text = function(text) {
   this.val = text;
+  this.mixedChildren.push(text);
 };
 
 XmlElement.prototype._cdata = function(cdata) {
   this.val = cdata;
   this.isValCdata=true;
+  this.mixedChildren.push(cdata);
 };
 
 XmlElement.prototype._comment = function(comment) {
   this.val = comment;
   this.isValComment=true;
+  this.mixedChildren.push(comment);
 }
 
 XmlElement.prototype._error = function(err) {
@@ -158,25 +162,25 @@ XmlElement.prototype.toStringWithIndent = function(indent, options) {
   }
   if (options && options.trimmed && finalVal.length > 25)
     finalVal = finalVal.substring(0,25).trim() + "…";
-  
+
   if (this.children.length) {
     s += ">" + linebreak;
 
     var childIndent = indent + (options && options.compressed ? "" : "  ");
-    
+
     if (finalVal.length)
       s += childIndent + finalVal + linebreak;
 
     for (var i=0, l=this.children.length; i<l; i++)
       s += this.children[i].toStringWithIndent(childIndent, options) + linebreak;
-    
+
     s += indent + "</" + this.name + ">";
   }
   else if (finalVal.length) {
     s += ">" + finalVal + "</" + this.name +">";
   }
   else s += "/>";
-  
+
   return s;
 };
 
@@ -193,7 +197,7 @@ function XmlDocument(xml) {
 
   // Stores doctype (if defined)
   this.doctype = "";
-
+  this.mixedChildren = [];
   // Expose the parser to the other delegates while the parser is running
   this.parser = sax.parser(true); // strict
   addParserEvents(this.parser);


### PR DESCRIPTION
Added a mixedChildren array into both XmlElement and XmlDocument and pushed both the children and values into it. Doesn't break existing usage. Fixes an issue where an xml element could have multiple text value children like <some>Text1<something/>Text2</some>