### PR TITLE
Fix CData overwriting bug

### DIFF
--- a/lib/xmldoc.js
+++ b/lib/xmldoc.js
@@ -26,8 +26,6 @@ function XmlElement(tag) {
   this.name = tag.name;
   this.attr = tag.attributes;
   this.val = "";
-  this.isValCdata = false;
-  this.isValComment = false;
   this.children = [];
   this.firstChild = null;
   this.lastChild = null;
@@ -39,18 +37,24 @@ function XmlElement(tag) {
   this.startTagPosition = parser.startTagPosition;
 }
 
-// SaxParser handlers
+// Private methods
 
-XmlElement.prototype._opentag = function(tag) {
-
-  var child = new XmlElement(tag);
-  
+XmlElement.prototype._addChild = function(child) {
   // add to our children array
   this.children.push(child);
 
   // update first/last pointers
   if (!this.firstChild) this.firstChild = child;
   this.lastChild = child;
+};
+
+// SaxParser handlers
+
+XmlElement.prototype._opentag = function(tag) {
+
+  var child = new XmlElement(tag);
+
+  this._addChild(child);
 
   delegates.unshift(child);
 };
@@ -60,18 +64,20 @@ XmlElement.prototype._closetag = function() {
 };
 
 XmlElement.prototype._text = function(text) {
-  this.val = text;
+  this.val += text;
+
+  this._addChild(new XmlTextNode(text));
 };
 
 XmlElement.prototype._cdata = function(cdata) {
-  this.val = cdata;
-  this.isValCdata=true;
+  this.val += cdata;
+
+  this._addChild(new XmlCDataNode(cdata));
 };
 
 XmlElement.prototype._comment = function(comment) {
-  this.val = comment;
-  this.isValComment=true;
-}
+  this._addChild(new XmlCommentNode(comment));
+};
 
 XmlElement.prototype._error = function(err) {
   throw err;
@@ -148,37 +154,69 @@ XmlElement.prototype.toStringWithIndent = function(indent, options) {
     if (Object.prototype.hasOwnProperty.call(this.attr, name))
         s += " " + name + '="' + escapeXML(this.attr[name]) + '"';
 
-  var finalVal = '';
-  if (this.isValCdata){
-    finalVal = '<![CDATA['+this.val+']]>';
-  } else if (preserveWhitespace) {
-    finalVal = escapeXML(this.val);
-  } else{
-    finalVal = escapeXML(this.val.trim());
+  if (this.children.length === 1 && this.children[0].type !== "element") {
+    s += ">" + this.children[0].toString(options) + "</" + this.name + ">";
   }
-  if (options && options.trimmed && finalVal.length > 25)
-    finalVal = finalVal.substring(0,25).trim() + "…";
-  
-  if (this.children.length) {
+  else if (this.children.length) {
     s += ">" + linebreak;
 
     var childIndent = indent + (options && options.compressed ? "" : "  ");
-    
-    if (finalVal.length)
-      s += childIndent + finalVal + linebreak;
 
-    for (var i=0, l=this.children.length; i<l; i++)
+    for (var i=0, l=this.children.length; i<l; i++) {
       s += this.children[i].toStringWithIndent(childIndent, options) + linebreak;
-    
+    }
+
     s += indent + "</" + this.name + ">";
   }
-  else if (finalVal.length) {
-    s += ">" + finalVal + "</" + this.name +">";
-  }
   else s += "/>";
-  
+
   return s;
 };
+
+// Alternative XML nodes
+
+function XmlTextNode (text) {
+  this.text = text;
+}
+
+XmlTextNode.prototype.toString = function(options) {
+  return formatText(escapeXML(this.text), options);
+};
+
+XmlTextNode.prototype.toStringWithIndent = function(indent, options) {
+  return indent+this.toString(options);
+};
+
+function XmlCDataNode (cdata) {
+  this.cdata = cdata;
+}
+
+XmlCDataNode.prototype.toString = function(options) {
+  return "<![CDATA["+formatText(this.cdata, options)+"]]>";
+};
+
+XmlCDataNode.prototype.toStringWithIndent = function(indent, options) {
+  return indent+this.toString(options);
+};
+
+function XmlCommentNode (comment) {
+  this.comment = comment;
+}
+
+XmlCommentNode.prototype.toString = function(options) {
+  return "<!--"+formatText(escapeXML(this.comment), options)+"-->";
+};
+
+XmlCommentNode.prototype.toStringWithIndent = function(indent, options) {
+  return indent+this.toString(options);
+};
+
+// Node type tag
+
+XmlElement.prototype.type = "element";
+XmlTextNode.prototype.type = "text";
+XmlCDataNode.prototype.type = "cdata";
+XmlCommentNode.prototype.type = "comment";
 
 /*
 XmlDocument is the class we expose to the user; it uses the sax parser to create a hierarchy
@@ -261,6 +299,18 @@ function extend(destination, source) {
 // escapes XML entities like "<", "&", etc.
 function escapeXML(value){
   return value.replace(/&/g, '&amp;').replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/'/g, '&apos;').replace(/"/g, '&quot;');
+}
+
+// formats some text for debugging given a few options
+function formatText(text, options) {
+  var finalText = text;
+
+  if (options && options.trimmed && text.length > 25)
+    finalText = finalText.substring(0,25).trim() + "…";
+  if (!(options && options.preserveWhitespace))
+    finalText = finalText.trim();
+
+  return finalText;
 }
 
 // Are we being used in a Node-like environment?

--- a/lib/xmldoc.js
+++ b/lib/xmldoc.js
@@ -64,6 +64,9 @@ XmlElement.prototype._closetag = function() {
 };
 
 XmlElement.prototype._text = function(text) {
+  if (typeof this.children === 'undefined')
+    return
+
   this.val += text;
 
   this._addChild(new XmlTextNode(text));
@@ -76,6 +79,9 @@ XmlElement.prototype._cdata = function(cdata) {
 };
 
 XmlElement.prototype._comment = function(comment) {
+  if (typeof this.children === 'undefined')
+    return
+
   this._addChild(new XmlCommentNode(comment));
 };
 

--- a/lib/xmldoc.js
+++ b/lib/xmldoc.js
@@ -87,7 +87,8 @@ XmlElement.prototype._error = function(err) {
 
 XmlElement.prototype.eachChild = function(iterator, context) {
   for (var i=0, l=this.children.length; i<l; i++)
-    if (iterator.call(context, this.children[i], i, this.children) === false) return;
+    if (this.children[i].type === "element")
+      if (iterator.call(context, this.children[i], i, this.children) === false) return;
 };
 
 XmlElement.prototype.childNamed = function(name) {
@@ -111,7 +112,7 @@ XmlElement.prototype.childrenNamed = function(name) {
 XmlElement.prototype.childWithAttribute = function(name,value) {
   for (var i=0, l=this.children.length; i<l; i++) {
     var child = this.children[i];
-    if ( (value && child.attr[name] === value) || (!value && child.attr[name]) )
+    if (child.type === "element" && ((value && child.attr[name] === value) || (!value && child.attr[name])))
       return child;
   }
   return undefined;
@@ -122,7 +123,7 @@ XmlElement.prototype.descendantWithPath = function(path) {
   var components = path.split('.');
 
   for (var i=0, l=components.length; i<l; i++)
-    if (descendant)
+    if (descendant && descendant.type === "element")
       descendant = descendant.childNamed(components[i]);
     else
       return undefined;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     {
       "name": "Nick Farina",
       "email": "nfarina@gmail.com"
+    },
+    {
+      "name": "Caleb Meredith",
+      "email": "calebmeredith8@gmail.com"
     }
   ],
   "readmeFilename": "README.md",

--- a/test/basic.js
+++ b/test/basic.js
@@ -158,9 +158,46 @@ t.test('eachChild', function (t) {
   t.end();
 })
 
+t.test('eachChild with text and comments', function (t) {
+
+  var xmlString = '<books><book title="Twilight"/>text!<book title="Twister"/><!--comment!--></books>';
+  var books = new XmlDocument(xmlString);
+
+  expectedTitles = ["Twilight", "Twister"];
+
+  var elI = 0;
+
+  books.eachChild(function(book, i, books) {
+    t.equal(book.attr.title, expectedTitles[elI++]);
+  });
+
+  called = 0;
+  books.eachChild(function(book, i, books) {
+    called++;
+    return false; // test that returning false short-circuits the loop
+  });
+  t.equal(called, 1);
+
+  t.end();
+})
+
 t.test('childNamed', function (t) {
 
   var xmlString = '<books><book/><good-book/></books>';
+  var books = new XmlDocument(xmlString);
+
+  var goodBook = books.childNamed('good-book');
+  t.equal(goodBook.name, 'good-book');
+
+  var badBook = books.childNamed('bad-book');
+  t.equal(badBook, undefined);
+
+  t.end();
+})
+
+t.test('childNamed with text', function (t) {
+
+  var xmlString = '<books><book/>text<good-book/></books>';
   var books = new XmlDocument(xmlString);
 
   var goodBook = books.childNamed('good-book');
@@ -202,6 +239,24 @@ t.test('childWithAttribute', function (t) {
   t.end();
 })
 
+t.test('childWithAttribute with text', function (t) {
+
+  var xmlString = '<fruits><apple pick="no"/><orange rotten="yes"/>text<apple pick="yes"/><banana/></fruits>';
+  var fruits = new XmlDocument(xmlString);
+
+  var pickedFruit = fruits.childWithAttribute('pick', 'yes');
+  t.equal(pickedFruit.name, 'apple');
+  t.equal(pickedFruit.attr.pick, 'yes');
+
+  var rottenFruit = fruits.childWithAttribute('rotten');
+  t.equal(rottenFruit.name, 'orange');
+
+  var peeled = fruits.childWithAttribute('peeled');
+  t.equal(peeled, undefined);
+
+  t.end();
+})
+
 t.test('descendantWithPath', function (t) {
 
   var xmlString = '<book><author><first>George R.R.</first><last>Martin</last></author></book>';
@@ -219,9 +274,43 @@ t.test('descendantWithPath', function (t) {
   t.end();
 })
 
+t.test('descendantWithPath with text', function (t) {
+
+  var xmlString = '<book><author>text<first>George R.R.</first><last>Martin</last></author></book>';
+  var book = new XmlDocument(xmlString);
+
+  var lastNameNode = book.descendantWithPath('author.last');
+  t.equal(lastNameNode.val, 'Martin');
+
+  var middleNameNode = book.descendantWithPath('author.middle');
+  t.equal(middleNameNode, undefined);
+
+  var publisherNameNode = book.descendantWithPath('publisher.first');
+  t.equal(publisherNameNode, undefined);
+
+  t.end();
+})
+
 t.test('valueWithPath', function (t) {
 
   var xmlString = '<book><author><first>George R.R.</first><last hyphenated="no">Martin</last></author></book>';
+  var book = new XmlDocument(xmlString);
+
+  var lastName = book.valueWithPath('author.last');
+  t.equal(lastName, 'Martin');
+
+  var lastNameHyphenated = book.valueWithPath('author.last@hyphenated');
+  t.equal(lastNameHyphenated, "no");
+
+  var publisherName = book.valueWithPath('publisher.last@hyphenated');
+  t.equal(publisherName, undefined);
+
+  t.end();
+})
+
+t.test('valueWithPath with text', function (t) {
+
+  var xmlString = '<book><author>text<first>George R.R.</first><last hyphenated="no">Martin</last></author></book>';
   var book = new XmlDocument(xmlString);
 
   var lastName = book.valueWithPath('author.last');

--- a/test/basic.js
+++ b/test/basic.js
@@ -112,6 +112,66 @@ t.test('text with elements handling', function (t) {
   t.end();
 })
 
+t.test('text before root node', function (t) {
+
+  var xmlString = '\n\n<hello>*</hello>';
+  var xml = new XmlDocument(xmlString);
+
+  t.equal(xml.val, '*');
+  t.equal(xml.children.length, 1);
+  t.end();
+})
+
+t.test('text after root node', function (t) {
+
+  var xmlString = '<hello>*</hello>\n\n';
+  var xml = new XmlDocument(xmlString);
+
+  t.equal(xml.val, '*');
+  t.equal(xml.children.length, 1);
+  t.end();
+})
+
+t.test('text before root node with version', function (t) {
+
+  var xmlString = '<?xml version="1.0"?>\n\n<hello>*</hello>';
+  var xml = new XmlDocument(xmlString);
+
+  t.equal(xml.val, '*');
+  t.equal(xml.children.length, 1);
+  t.end();
+})
+
+t.test('text after root node with version', function (t) {
+
+  var xmlString = '<?xml version="1.0"?><hello>*</hello>\n\n';
+  var xml = new XmlDocument(xmlString);
+
+  t.equal(xml.val, '*');
+  t.equal(xml.children.length, 1);
+  t.end();
+})
+
+t.test('comment before root node', function (t) {
+
+  var xmlString = '<!-- hello --><world>*</world>';
+  var xml = new XmlDocument(xmlString);
+
+  t.equal(xml.val, '*');
+  t.equal(xml.children.length, 1);
+  t.end();
+})
+
+t.test('comment after root node', function (t) {
+
+  var xmlString = '<hello>*</hello><!-- world -->';
+  var xml = new XmlDocument(xmlString);
+
+  t.equal(xml.val, '*');
+  t.equal(xml.children.length, 1);
+  t.end();
+})
+
 t.test('error handling', function (t) {
 
   var xmlString = '<hello><unclosed-tag></hello>';


### PR DESCRIPTION
I have some XML that looks like this:

```xml
      <content:encoded>
<![CDATA[<a name="How.to.meet.someone.new"></a>
<h1>How to meet someone new</h1>

<a name="L.and.make.them.like.you."></a>
<h2>(and make them like you)</h2>

<ul>
<li>Smile</li>
<li>Be inquisitive, ask thoughtful questions</li>
<li>body language, mirroring</li>
<li>Be open to peoples POV</li>
<li>What are your Goals when meeting someone new?</li>
</ul>

]]>
      </content:encoded>
```

Which is valid XML. However, when parsed by `xmldoc` the `val` property for the `content:encoded` element is: `'\n      '`. This is because the white space (in this case `'\n      '`) emits a `text` event in the SAX parser after a `cdata` event has already been emit. So the `text` event overrides the `cdata` event even though `isValCdata` is true. This behavior seems to be very fault intolerant for what is acceptable by most other XML parsers. As another note, this behavior also makes XML that looks like `<a>b<c/>d</a>` very difficult to work with.

This PR changes the behavior of this library so that comments, cdata, and text may all be treated as XML nodes similarly to the `XMLElement` object. The `val` property is still maintained for convenience by appending cdata and text values, but to get comments you now have to look at the `children` array.

The breaking changes that occur because of this change:

- No more `isValCData` or `isValComment`. An element can have more then one child node type.
- Comments are no longer added to `val`. You can find them in `children` instead.
- The `children`, `firstChild`, and `lastChild` properties may be a text, cdata, comment, or element object and not just an element object as they were in the past. To help filter out the objects you don’t want, use the new `type` property.

If you only use the convenience methods, nothing should change for you.

There are simpler ways to fix the bug I expressed above, I just feel like this is an important change to make for the stability of this library given it may cause other bugs.

Thanks so much for your work, this is a great library 👍 

[Edit by @nfarina]: Closes #23, #40