### PR TITLE
Allow to set preserveEmpty option

### DIFF
--- a/lib/xmldoc.js
+++ b/lib/xmldoc.js
@@ -175,7 +175,7 @@ XmlElement.prototype.toStringWithIndent = function(indent, options) {
 
     s += indent + "</" + this.name + ">";
   }
-  else s += "/>";
+  else s += options && options.preserveEmpty ? "></" + this.name + ">" : "/>";
 
   return s;
 };

--- a/lib/xmldoc.js
+++ b/lib/xmldoc.js
@@ -175,7 +175,14 @@ XmlElement.prototype.toStringWithIndent = function(indent, options) {
 
     s += indent + "</" + this.name + ">";
   }
-  else s += options && options.preserveEmpty ? "></" + this.name + ">" : "/>";
+  else if (options && options.html) {
+    var whiteList = ["br", "img", "input", "link", "meta"];
+    if (whiteList.indexOf(this.name) !== -1) s += "/>";
+    else s += "></" + this.name + ">";
+  }
+  else {
+    s += "/>";
+  }
 
   return s;
 };


### PR DESCRIPTION
Basically it allows to decide whether `<item></item>` will be printed when using `toString()` or it's displayed as `<item/>`.
This is pretty useful when working around with HTML tags since browser won't interpret an empty `<div/>` tag correctly, which messed my HTML file.

Example usage:
```js
var item = new xmldoc.XmlDocument("<item></item>");
item.toString({ preserveEmpty: true }); //<item></item>
item.toString(); //<item/>
```