### PR TITLE
Fixing license id

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "tap test/*.js",
     "coverage": "npm test -- --cov --coverage-report=html"
   },
-  "license": "https://raw.github.com/nfarina/xmldoc-js/master/LICENSE",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/nfarina/xmldoc.git"


### PR DESCRIPTION
The license id field contains a (broken) URL rather than the more typical license id. I've replaced it with "MIT" (which is shockingly the SPDX id for MIT :) ).