### PR TITLE
Error if delegate is null

### DIFF
--- a/lib/xmldoc.js
+++ b/lib/xmldoc.js
@@ -1,4 +1,4 @@
-(function () {
+t(function () {
   var sax;
 
   if (
@@ -29,8 +29,8 @@
     // from the current execution stack.
     if (!parser) {
       var delegate = delegates[delegates.length - 1];
-
-      if (delegate.parser) {
+      // error if delegate is null!
+      if (delegate && delegate.parser) {
         parser = delegate.parser;
       }
     }


### PR DESCRIPTION
hi 
Hi @nfarina , I'm using your library and I find it really convenient! However, I've encountered an issue while trying to create a new XmlElement. This is because within this function, it is assumed that `delegate` is not null. For now, I've resolved it by adding an additional condition before `delegate.parser`, as you'll see in the pull request.

Have a great day,
Amedeo