### PR TITLE
Fix mising parser on child element

### DIFF
--- a/test/ts/basic.ts
+++ b/test/ts/basic.ts
@@ -46,6 +46,7 @@ describe("Child navigation", () => {
 
     const goodBook = books.childNamed("good-book");
     expect(goodBook?.name).toBe("good-book");
+    expect(goodBook?.position).toBe(26);
 
     const badBook = books.childNamed("bad-book");
     expect(badBook).toBeUndefined();
@@ -59,6 +60,7 @@ describe("Child navigation", () => {
     expect(bookNodes.length).toBe(2);
     expect(bookNodes[0].name).toBe("book");
     expect(bookNodes[1].name).toBe("book");
+    expect(bookNodes[1].position).toBe(21);
   });
 });
 
@@ -71,6 +73,7 @@ describe("Descendant search", () => {
 
     const bookNodes = library.descendantsNamed("book");
     expect(bookNodes.length).toBe(3);
+    expect(bookNodes[1].position).toBe(39);
   });
 
   test("descendantWithPath follows dot notation path", () => {

--- a/xmldoc.ts
+++ b/xmldoc.ts
@@ -168,9 +168,6 @@ export class XmlElement implements XmlNodeBase, XmlDelegate {
   /** Character position of the start tag in the original XML */
   startTagPosition: number | null;
 
-  /** The SAX parser instance (available only during parsing) */
-  parser?: SAXParser;
-
   /**
    * Creates a new XML element
    * @param tag The tag name and attributes
@@ -185,7 +182,7 @@ export class XmlElement implements XmlNodeBase, XmlDelegate {
     if (!parser && delegates.length) {
       var delegate = delegates[delegates.length - 1];
 
-      if (delegate.parser) {
+      if ("parser" in delegate) {
         parser = delegate.parser;
       }
     }
@@ -220,8 +217,6 @@ export class XmlElement implements XmlNodeBase, XmlDelegate {
     const child = new XmlElement(tag);
     this._addChild(child);
     delegates.unshift(child);
-    // Remove the parser as it is no longer needed and should not be exposed to clients
-    delete this.parser;
   }
 
   _closetag(): void {


### PR DESCRIPTION
Found another occurence when the parser is deleted from document before all children are parsed.

- #79